### PR TITLE
Run under bash explicitly (`Illegal option -o errtrace` in Linux)

### DIFF
--- a/bin/nodejs-install
+++ b/bin/nodejs-install
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # strict is better.


### PR DESCRIPTION
On Linux, running `nodejs-install` fails with error:

```
Illegal option -o errtrace
```

Most Linux distributions use either original `sh` or `dash`, and errtrace is supported only in bash, which I suppose is the default shell in macOS.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wilmoore/nodejs-install/1)

<!-- Reviewable:end -->
